### PR TITLE
track loss for TensorBoard

### DIFF
--- a/tensorflow/tf-estimators.ipynb
+++ b/tensorflow/tf-estimators.ipynb
@@ -498,6 +498,7 @@
     "        loss = tf.reduce_mean(\n",
     "            tf.nn.sigmoid_cross_entropy_with_logits(logits=logit, labels=labels, name='loss')\n",
     "        )\n",
+    "        tf.summary.scalar('loss', loss)        \n",
     "\n",
     "    if mode == MODES.TRAIN:\n",
     "        learning_rate = params.get('learning_rate')\n",
@@ -578,7 +579,9 @@
    },
    "outputs": [],
    "source": [
-    "regressor = tf.estimator.Estimator(model_fn, model_dir=MODEL_DIR, params={'learning_rate': LEARNING_RATE})"
+    "run_config = tf.estimator.RunConfig().replace(save_summary_steps=10)\n",
+    "regressor = tf.estimator.Estimator(model_fn, model_dir=MODEL_DIR, params={'learning_rate': LEARNING_RATE},\n",
+    "                                   config=run_config)"
    ]
   },
   {
@@ -1242,30 +1245,6 @@
   }
  ],
  "metadata": {
-  "colab": {
-   "default_view": {},
-   "name": "tf-estimators.ipynb",
-   "provenance": [],
-   "version": "0.3.2",
-   "views": {}
-  },
-  "kernelspec": {
-   "display_name": "Python 2",
-   "language": "python",
-   "name": "python2"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 2
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
-  }
  },
  "nbformat": 4,
  "nbformat_minor": 1


### PR DESCRIPTION
I was thinking it might be fun to add a 'loss' summary (for TensorBoard), then I updated the config to save summary info more often, since you're only running for 200 steps.  If you don't like the idea, feel free to reject :).

Also, I removed the metadata info, since from workshop experience that seems to sometimes cause trouble.