### PR TITLE
Use sklearn's native joblib

### DIFF
--- a/gce/burst-training/census-analysis.py
+++ b/gce/burst-training/census-analysis.py
@@ -14,7 +14,6 @@
 
 
 import argparse
-import joblib
 import numpy as np
 import os
 import pandas as pd
@@ -23,6 +22,7 @@ import scipy
 import sklearn
 
 from sklearn.ensemble import GradientBoostingClassifier
+from sklearn.externals import joblib
 from sklearn.model_selection import RandomizedSearchCV
 
 

--- a/gce/burst-training/image.sh
+++ b/gce/burst-training/image.sh
@@ -16,7 +16,7 @@
 
 sudo apt-get update && apt-get install -y python-pip
 
-sudo pip install joblib numpy pandas scipy scikit-learn tensorflow xgboost
+sudo pip install numpy pandas scipy scikit-learn tensorflow xgboost
 
 sudo shutdown -h now
 

--- a/gce/burst-training/requirements.txt
+++ b/gce/burst-training/requirements.txt
@@ -4,7 +4,6 @@ enum34==1.1.6
 funcsigs==1.0.2
 futures==3.2.0
 html5lib==0.9999999
-joblib==0.11
 Markdown==2.6.10
 mock==2.0.0
 numpy==1.13.3


### PR DESCRIPTION
`scikit-learn` bundles `joblib`, so we can skip installing it separately I think.