### PR TITLE
Burst training bugfix

### DIFF
--- a/gce/burst-training/README.md
+++ b/gce/burst-training/README.md
@@ -273,7 +273,7 @@ Once you have built your VM image, you can run this script to execute your first
 burst training job as follows:
 
 ```
-./train.sh <TRAINING-INSTANCE-NAME> <BUCKET-NAME> <IMAGE-FAMILY>
+./train.sh <TRAINING-INSTANCE-NAME> gs://<BUCKET-NAME> <IMAGE-FAMILY>
 ```
 
 Here, `<BUCKET-NAME>` and `<IMAGE-FAMILY>` should have the same values as above.

--- a/gce/burst-training/train.sh
+++ b/gce/burst-training/train.sh
@@ -27,7 +27,7 @@ gcloud compute instances create \
   --machine-type=n1-standard-64 \
   --image-family=$IMAGE_FAMILY \
   --metadata-from-file startup-script=census-startup.sh \
-  --metadata BUCKET_NAME=$BUCKET_NAME,TRAINING_SCRIPT_FILE=census-analysis.py,CENSUS_DATA_PATH=$BUCKET_NAME/census,MODEL_OUTPUT_PATH=$BUCKET_NAME/census-$TIMESTAMP.model,CV_ITERATIONS=300 \
+  --metadata TRAINING_SCRIPT_DIR=$BUCKET_NAME,TRAINING_SCRIPT_FILE=census-analysis.py,CENSUS_DATA_PATH=$BUCKET_NAME/census,MODEL_OUTPUT_PATH=$BUCKET_NAME/census-$TIMESTAMP.model,CV_ITERATIONS=300 \
   --scopes=cloud-platform \
   --preemptible \
   $INSTANCE_NAME


### PR DESCRIPTION
Target: gce/burst-training
Content:
- Typo README: A missing 'gs://' in front of 'BUCKET-NAME' in the call of train.sh
- BugFix train.sh:  replacing BUCKET_NAME key-metadata with TRAINING_SCRIPT_DIR