### PR TITLE
Adds notice that these samples are moving to ai-platform-samples

### DIFF
--- a/tutorials/explanations/README.md
+++ b/tutorials/explanations/README.md
@@ -1,5 +1,7 @@
 # AI Explanations samples
 
+NOTE: Future updates to these samples will be made in the [ai-platform-samples](https://github.com/GoogleCloudPlatform/ai-platform-samples/tree/master/notebooks/samples/explanations) repo.
+
 This directory contains samples for using Explanations on Cloud AI Platform. The following notebooks are available:
 
 * [Training, deploying, and explaining a tabular data model](https://github.com/GoogleCloudPlatform/ml-on-gcp/tree/master/tutorials/explanations/ai-explanations-tabular.ipynb)


### PR DESCRIPTION
Adds a notice that these samples are moving to ai-platform-samples. We will leave the older versions here to avoid broken link issues.

Wait to merge this until [this PR](https://github.com/GoogleCloudPlatform/ai-platform-samples/pull/158) is merged. It copies #108 to ai-platform-samples.

Should we also add that notice to the top of each notebook file?