### PR TITLE
Use regional ML API endpoint in ai-explanations-image.ipynb

### DIFF
--- a/tutorials/explanations/ai-explanations-image.ipynb
+++ b/tutorials/explanations/ai-explanations-image.ipynb
@@ -262,6 +262,8 @@
         "import warnings\n",
         "import googleapiclient\n",
         "\n",
+        "from google.api_core.client_options import ClientOptions\n",
+        "\n",
         "warnings.filterwarnings('ignore')\n",
         "os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3' \n",
         "# If you are running this notebook in Colab, follow the\n",
@@ -987,7 +989,7 @@
       },
       "source": [
         "# Create the model if it doesn't exist yet (you only need to run this once)\n",
-        "!gcloud ai-platform models create $MODEL --enable-logging --regions=us-central1"
+        "!gcloud ai-platform models create $MODEL --enable-logging --region $REGION"
       ],
       "execution_count": null,
       "outputs": []
@@ -1051,7 +1053,8 @@
         "--python-version 3.7 \\\n",
         "--machine-type n1-standard-4 \\\n",
         "--explanation-method integrated-gradients \\\n",
-        "--num-integral-steps 25"
+        "--num-integral-steps 25 \\\n",
+        "--region $REGION"
       ],
       "execution_count": null,
       "outputs": []
@@ -1065,7 +1068,7 @@
       },
       "source": [
         "# Make sure the IG model deployed correctly. State should be `READY` in the following log\n",
-        "!gcloud ai-platform versions describe $IG_VERSION --model $MODEL"
+        "!gcloud ai-platform versions describe $IG_VERSION --model $MODEL --region $REGION"
       ],
       "execution_count": null,
       "outputs": []
@@ -1111,7 +1114,8 @@
         "--python-version 3.7 \\\n",
         "--machine-type n1-standard-4 \\\n",
         "--explanation-method xrai \\\n",
-        "--num-integral-steps 25"
+        "--num-integral-steps 25 \\\n",
+        "--region $REGION"
       ],
       "execution_count": null,
       "outputs": []
@@ -1125,7 +1129,7 @@
       },
       "source": [
         "# Make sure the XRAI model deployed correctly. State should be `READY` in the following log\n",
-        "!gcloud ai-platform versions describe $XRAI_VERSION --model $MODEL"
+        "!gcloud ai-platform versions describe $XRAI_VERSION --model $MODEL --region $REGION"
       ],
       "execution_count": null,
       "outputs": []
@@ -1151,7 +1155,7 @@
       },
       "source": [
         "# Download test flowers from public bucket\n",
-        "!mkdir flowers\n",
+        "!mkdir -p flowers\n",
         "!gsutil -m cp gs://flowers_model/test_flowers/* ./flowers"
       ],
       "execution_count": null,
@@ -1234,6 +1238,7 @@
         "            model.\n",
         "    \"\"\"\n",
         "\n",
+        "    client_options = ClientOptions(api_endpoint=f'https://{REGION}-ml.googleapis.com')\n",
         "    service = googleapiclient.discovery.build('ml', 'v1')\n",
         "    name = 'projects/{}/models/{}'.format(project, model)\n",
         "\n",


### PR DESCRIPTION
and fix a few other commands.

* Use a regional ML API endpoint instead of global.
  * N1 VMs aren't available in global.
  * Must also specify the region later when creating the model version
    to prevent a not found error.
* Use the parameterized `REGION` instead of hardcoded `us-central1`
  strings.
* Use `mkdir -p flowers` instead of `mkdir flowers` to not fail if the
  dir already exists.

TODO: this notebook doesn't run successfully yet because of this issue:
https://github.com/GoogleCloudPlatform/ml-on-gcp/issues/133